### PR TITLE
Typescript definition fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ type HTML = import('uhtml').Tag<HTMLElement>;
 type SVG = import('uhtml').Tag<SVGElement>;
 type CSS = (strings: TemplateStringsArray, ...values: unknown[]) => string;
 type Render<T, U> = (
-  this: T & U & { html: HTML; render: Render<T, U> } & HTMLElement,
+  this: {props: T} & U & { html: HTML; render: Render<T, U> } & HTMLElement,
 ) => unknown;
 
 export const css: CSS;

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ export interface Definition<T = void, U = void> {
    * and *always* before connected/attributeChanged/props
    */
   init?: (
-    this: { props: T } & U & { html: HTML; render: Render<T, U> } & HTMLElement,
+    this: { props: T } & U & HTMLElement & { html: HTML; render: Render<T, U> },
   ) => unknown;
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ type HTML = import('uhtml').Tag<HTMLElement>;
 type SVG = import('uhtml').Tag<SVGElement>;
 type CSS = (strings: TemplateStringsArray, ...values: unknown[]) => string;
 type Render<T, U> = (
-  this: T & U & { html: HTML; render: Render<T, U> },
+  this: T & U & { html: HTML; render: Render<T, U> } & HTMLElement,
 ) => unknown;
 
 export const css: CSS;
@@ -65,7 +65,7 @@ export interface Definition<T = void, U = void> {
    * and *always* before connected/attributeChanged/props
    */
   init?: (
-    this: { props: T } & U & { html: HTML; render: Render<T, U> },
+    this: { props: T } & U & { html: HTML; render: Render<T, U> } & HTMLElement,
   ) => unknown;
 
   /**


### PR DESCRIPTION
* `render` and `init`: extend "this" from `HTMLElement` (to be able to access HTMLElement attributes)
* In `render`, "this" should not extend `T`
