### PR TITLE
uce as global even if used as a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var uce = (function (exports) {
+self.uce = (function (exports) {
   'use strict';
 
   


### PR DESCRIPTION
Since `uce` is supposed to be global here, this should also work if the file is included as a module.
Also consistent with wickedElements