### PR TITLE
Correct the typing of define.props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ export interface Definition<T = void, U = void> {
    * is by prefixing the attribute via `.`, that is:
    * this.html`<my-comp .prop=${value}/>`;
    */
-  props?: T;
+  props?: Partial<U> | null;
 
   /**
    * if present, all names will be automatically bound to the element


### PR DESCRIPTION
From [the discussion in PR 17](https://github.com/WebReflection/uce/pull/17#issuecomment-877716558):

- Define `props` as part of (internal, "private state")`OwnProps` instead of (external, "public interface") `Props`.
- Allow `props` to be `null`.