### PR TITLE
Update define method logic to handle adding formAssociated static pro…

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -29,6 +29,7 @@ const define = (tagName, definition) => {
     bound,
     connected,
     disconnected,
+    formAssociated,
     handleEvent,
     init,
     observedAttributes,
@@ -140,6 +141,10 @@ const define = (tagName, definition) => {
     if (attributeChanged)
       attributeChanged.apply(this, arguments);
   }};
+
+  if (formAssociated) {
+    statics.formAssociated = {value: formAssociated};
+  }
 
   proto.connectedCallback = {value() {
     bootstrap(this);


### PR DESCRIPTION
To help facilitate the participation of custom elements in HTML forms via the [attachInternals method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals), I'd like to submit the following update to the `define` method's logic.

To allow ElementInternals to work as intended, the custom element needs a static formAssociated property set to true. With this change, the `define` method would now look for a `formAssociated` property within the object passed, and add that pairing to the custom element's static properties just as is being done with observedAttributes currently.

This logic appears in multiple files so I wasn't entirely sure where to make the baseline change that would carry the logic over to all other files when building. So if using the `/cjs/index.js` file as the baseline is not correct, please let me know and I would be happy to make whatever changes are necessary. Similarly, if an npm script needs to be run in this case as a part of this PR, please let me know that as well.